### PR TITLE
feat: three-page onboarding with theme choice

### DIFF
--- a/lib/core/services/theme_service.dart
+++ b/lib/core/services/theme_service.dart
@@ -1,0 +1,52 @@
+import 'package:flutter/material.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+enum AppTheme { light, dark, highContrast }
+
+class ThemeService extends ChangeNotifier {
+  ThemeService(this._prefs);
+
+  static const _themeKey = 'theme';
+  static const _firstLaunchKey = 'firstLaunch';
+
+  final SharedPreferences _prefs;
+  AppTheme _theme = AppTheme.light;
+  bool _firstLaunch = true;
+
+  Future<void> init() async {
+    final themeStr = _prefs.getString(_themeKey);
+    if (themeStr != null) {
+      _theme = AppTheme.values.firstWhere(
+        (e) => e.name == themeStr,
+        orElse: () => AppTheme.light,
+      );
+    }
+    _firstLaunch = _prefs.getBool(_firstLaunchKey) ?? true;
+  }
+
+  AppTheme get theme => _theme;
+  bool get firstLaunch => _firstLaunch;
+
+  ThemeData get themeData {
+    switch (_theme) {
+      case AppTheme.dark:
+        return ThemeData.dark(useMaterial3: true);
+      case AppTheme.highContrast:
+        return ThemeData.highContrastLight(useMaterial3: true);
+      case AppTheme.light:
+      default:
+        return ThemeData(useMaterial3: true, colorSchemeSeed: Colors.deepPurple);
+    }
+  }
+
+  Future<void> toggleTheme(AppTheme theme) async {
+    _theme = theme;
+    await _prefs.setString(_themeKey, theme.name);
+    notifyListeners();
+  }
+
+  Future<void> setFirstLaunchFalse() async {
+    _firstLaunch = false;
+    await _prefs.setBool(_firstLaunchKey, false);
+  }
+}

--- a/lib/features/onboarding/bindings.dart
+++ b/lib/features/onboarding/bindings.dart
@@ -1,0 +1,10 @@
+import 'package:get_it/get_it.dart';
+
+import 'presentation/controller/onboarding_controller.dart';
+
+class OnboardingBindings {
+  static void register() {
+    final getIt = GetIt.instance;
+    getIt.registerFactory<OnboardingController>(OnboardingController.new);
+  }
+}

--- a/lib/features/onboarding/presentation/controller/onboarding_controller.dart
+++ b/lib/features/onboarding/presentation/controller/onboarding_controller.dart
@@ -1,0 +1,35 @@
+import 'package:flutter/material.dart';
+import 'package:get_it/get_it.dart';
+
+import '../../../../core/services/theme_service.dart';
+
+class OnboardingController extends ChangeNotifier {
+  OnboardingController() : _themeService = GetIt.I<ThemeService>();
+
+  final ThemeService _themeService;
+  final PageController pageController = PageController();
+  int currentPage = 0;
+
+  void nextPage() {
+    if (currentPage < 2) {
+      currentPage++;
+      pageController.animateToPage(
+        currentPage,
+        duration: const Duration(milliseconds: 300),
+        curve: Curves.easeInOut,
+      );
+      notifyListeners();
+    }
+  }
+
+  void selectTheme(AppTheme theme) {
+    _themeService.toggleTheme(theme);
+    notifyListeners();
+  }
+
+  Future<void> finish() async {
+    await _themeService.setFirstLaunchFalse();
+  }
+
+  AppTheme get theme => _themeService.theme;
+}

--- a/lib/features/onboarding/presentation/pages/intro_page.dart
+++ b/lib/features/onboarding/presentation/pages/intro_page.dart
@@ -1,0 +1,38 @@
+import 'package:flutter/material.dart';
+
+import '../controller/onboarding_controller.dart';
+
+class IntroPage extends StatelessWidget {
+  const IntroPage({super.key, required this.controller});
+
+  final OnboardingController controller;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.all(24),
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          const Icon(Icons.auto_awesome, size: 120),
+          const SizedBox(height: 32),
+          Text(
+            'Welcome to Habit Hero',
+            style: Theme.of(context).textTheme.headlineMedium,
+            textAlign: TextAlign.center,
+          ),
+          const SizedBox(height: 16),
+          const Text(
+            'Track and improve your habits with ease.',
+            textAlign: TextAlign.center,
+          ),
+          const Spacer(),
+          ElevatedButton(
+            onPressed: controller.nextPage,
+            child: const Text('Next'),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/features/onboarding/presentation/pages/onboarding_page.dart
+++ b/lib/features/onboarding/presentation/pages/onboarding_page.dart
@@ -1,0 +1,72 @@
+import 'package:flutter/material.dart';
+import 'package:get_it/get_it.dart';
+import 'package:go_router/go_router.dart';
+
+import '../../../../routes/app_pages.dart';
+import '../../../onboarding/presentation/controller/onboarding_controller.dart';
+import '../../../onboarding/presentation/pages/intro_page.dart';
+import '../../../onboarding/presentation/pages/privacy_page.dart';
+import '../../../onboarding/presentation/pages/theme_choice_page.dart';
+import '../../../onboarding/presentation/widgets/progress_dots.dart';
+
+class OnboardingPage extends StatefulWidget {
+  const OnboardingPage({super.key});
+
+  @override
+  State<OnboardingPage> createState() => _OnboardingPageState();
+}
+
+class _OnboardingPageState extends State<OnboardingPage> {
+  late final OnboardingController controller;
+
+  @override
+  void initState() {
+    super.initState();
+    controller = GetIt.I<OnboardingController>();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: AnimatedBuilder(
+        animation: controller,
+        builder: (context, _) {
+          return Column(
+            children: [
+              Expanded(
+                child: PageView(
+                  controller: controller.pageController,
+                  physics: const NeverScrollableScrollPhysics(),
+                  children: [
+                    IntroPage(controller: controller),
+                    PrivacyPage(controller: controller),
+                    ThemeChoicePage(controller: controller),
+                  ],
+                ),
+              ),
+              const SizedBox(height: 16),
+              ProgressDots(current: controller.currentPage, total: 3),
+              const SizedBox(height: 16),
+              if (controller.currentPage == 2)
+                ElevatedButton(
+                  onPressed: () async {
+                    await controller.finish();
+                    if (context.mounted) {
+                      context.go(AppPages.home);
+                    }
+                  },
+                  child: const Text('Get Started'),
+                )
+              else
+                ElevatedButton(
+                  onPressed: controller.nextPage,
+                  child: const Text('Next'),
+                ),
+              const SizedBox(height: 32),
+            ],
+          );
+        },
+      ),
+    );
+  }
+}

--- a/lib/features/onboarding/presentation/pages/privacy_page.dart
+++ b/lib/features/onboarding/presentation/pages/privacy_page.dart
@@ -1,0 +1,38 @@
+import 'package:flutter/material.dart';
+
+import '../controller/onboarding_controller.dart';
+
+class PrivacyPage extends StatelessWidget {
+  const PrivacyPage({super.key, required this.controller});
+
+  final OnboardingController controller;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.all(24),
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          const Icon(Icons.privacy_tip, size: 120),
+          const SizedBox(height: 32),
+          Text(
+            'Privacy First',
+            style: Theme.of(context).textTheme.headlineMedium,
+            textAlign: TextAlign.center,
+          ),
+          const SizedBox(height: 16),
+          const Text(
+            'Your data stays on your device.',
+            textAlign: TextAlign.center,
+          ),
+          const Spacer(),
+          ElevatedButton(
+            onPressed: controller.nextPage,
+            child: const Text('Next'),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/features/onboarding/presentation/pages/theme_choice_page.dart
+++ b/lib/features/onboarding/presentation/pages/theme_choice_page.dart
@@ -1,0 +1,81 @@
+import 'package:flutter/material.dart';
+
+import '../../../../core/services/theme_service.dart';
+import '../controller/onboarding_controller.dart';
+
+class ThemeChoicePage extends StatelessWidget {
+  const ThemeChoicePage({super.key, required this.controller});
+
+  final OnboardingController controller;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = controller.theme;
+    return Padding(
+      padding: const EdgeInsets.all(24),
+      child: Column(
+        children: [
+          const Spacer(),
+          Text(
+            'Choose your theme',
+            style: Theme.of(context).textTheme.headlineMedium,
+          ),
+          const SizedBox(height: 24),
+          Row(
+            mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+            children: AppTheme.values
+                .map(
+                  (t) => _ThemeCard(
+                    title: t.name,
+                    selected: theme == t,
+                    onTap: () => controller.selectTheme(t),
+                  ),
+                )
+                .toList(),
+          ),
+          const Spacer(),
+          ElevatedButton(
+            onPressed: controller.finish,
+            child: const Text('Get Started'),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _ThemeCard extends StatelessWidget {
+  const _ThemeCard({
+    required this.title,
+    required this.selected,
+    required this.onTap,
+  });
+
+  final String title;
+  final bool selected;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    return GestureDetector(
+      onTap: onTap,
+      child: Card(
+        color: selected ? Theme.of(context).colorScheme.primary : null,
+        child: SizedBox(
+          width: 80,
+          height: 100,
+          child: Center(
+            child: Text(
+              title,
+              style: TextStyle(
+                color: selected
+                    ? Theme.of(context).colorScheme.onPrimary
+                    : null,
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/onboarding/presentation/widgets/progress_dots.dart
+++ b/lib/features/onboarding/presentation/widgets/progress_dots.dart
@@ -1,0 +1,29 @@
+import 'package:flutter/material.dart';
+
+class ProgressDots extends StatelessWidget {
+  const ProgressDots({super.key, required this.current, required this.total});
+
+  final int current;
+  final int total;
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      mainAxisAlignment: MainAxisAlignment.center,
+      children: List.generate(
+        total,
+        (index) => Container(
+          margin: const EdgeInsets.symmetric(horizontal: 4),
+          width: current == index ? 12 : 8,
+          height: current == index ? 12 : 8,
+          decoration: BoxDecoration(
+            shape: BoxShape.circle,
+            color: current == index
+                ? Theme.of(context).colorScheme.primary
+                : Theme.of(context).colorScheme.outline,
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,36 +1,35 @@
 import 'package:flutter/material.dart';
+import 'package:get_it/get_it.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 
-void main() {
+import 'core/services/theme_service.dart';
+import 'features/onboarding/bindings.dart';
+import 'routes/app_pages.dart';
+
+Future<void> main() async {
+  WidgetsFlutterBinding.ensureInitialized();
+  final prefs = await SharedPreferences.getInstance();
+  GetIt.I.registerSingleton<ThemeService>(ThemeService(prefs));
+  await GetIt.I<ThemeService>().init();
+  OnboardingBindings.register();
   runApp(const MyApp());
 }
 
 class MyApp extends StatelessWidget {
   const MyApp({super.key});
 
-  // This widget is the root of your application.
   @override
   Widget build(BuildContext context) {
-    return MaterialApp(
-      title: 'Flutter Demo',
-      theme: ThemeData(
-        // This is the theme of your application.
-        //
-        // TRY THIS: Try running your application with "flutter run". You'll see
-        // the application has a purple toolbar. Then, without quitting the app,
-        // try changing the seedColor in the colorScheme below to Colors.green
-        // and then invoke "hot reload" (save your changes or press the "hot
-        // reload" button in a Flutter-supported IDE, or press "r" if you used
-        // the command line to start the app).
-        //
-        // Notice that the counter didn't reset back to zero; the application
-        // state is not lost during the reload. To reset the state, use hot
-        // restart instead.
-        //
-        // This works for code too, not just values: Most code changes can be
-        // tested with just a hot reload.
-        colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple),
-      ),
-      home: const MyHomePage(title: 'Flutter Demo Home Page'),
+    final themeService = GetIt.I<ThemeService>();
+    return AnimatedBuilder(
+      animation: themeService,
+      builder: (context, _) {
+        return MaterialApp.router(
+          title: 'Habit Hero',
+          routerConfig: AppPages.router,
+          theme: themeService.themeData,
+        );
+      },
     );
   }
 }

--- a/lib/routes/app_pages.dart
+++ b/lib/routes/app_pages.dart
@@ -1,0 +1,31 @@
+import 'package:get_it/get_it.dart';
+import 'package:go_router/go_router.dart';
+
+import '../core/services/theme_service.dart';
+import '../features/onboarding/presentation/pages/onboarding_page.dart';
+import '../main.dart';
+
+class AppPages {
+  static const home = '/home';
+  static const onboarding = '/onboarding';
+
+  static final router = GoRouter(
+    routes: [
+      GoRoute(
+        path: '/',
+        redirect: (context, state) {
+          final service = GetIt.I<ThemeService>();
+          return service.firstLaunch ? onboarding : home;
+        },
+      ),
+      GoRoute(
+        path: onboarding,
+        builder: (context, state) => const OnboardingPage(),
+      ),
+      GoRoute(
+        path: home,
+        builder: (context, state) => const MyHomePage(title: 'Habit Hero'),
+      ),
+    ],
+  );
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -34,6 +34,9 @@ dependencies:
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^1.0.8
+  get_it: ^7.6.0
+  go_router: ^13.2.0
+  shared_preferences: ^2.2.2
 
 dev_dependencies:
   flutter_test:

--- a/test/onboarding_controller_test.dart
+++ b/test/onboarding_controller_test.dart
@@ -1,0 +1,27 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:get_it/get_it.dart';
+import 'package:habit_hero_new/core/services/theme_service.dart';
+import 'package:habit_hero_new/features/onboarding/presentation/controller/onboarding_controller.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late OnboardingController controller;
+
+  setUp(() async {
+    SharedPreferences.setMockInitialValues({});
+    final prefs = await SharedPreferences.getInstance();
+    final themeService = ThemeService(prefs);
+    await themeService.init();
+    GetIt.I.registerSingleton<ThemeService>(themeService);
+    controller = OnboardingController();
+  });
+
+  test('nextPage increments currentPage', () {
+    expect(controller.currentPage, 0);
+    controller.nextPage();
+    expect(controller.currentPage, 1);
+  });
+}


### PR DESCRIPTION
## Summary
- add ThemeService for theme mode and first launch persistence
- implement onboarding controller, pages and progress dots
- configure routes with GetIt and GoRouter
- wire onboarding and theme service into main app
- create onboarding controller test

## Testing
- `dart analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687753199a548329bbb47c32b4176257