### PR TITLE
feat: add hive storage dependencies

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -36,7 +36,9 @@ dependencies:
   cupertino_icons: ^1.0.8
   get_it: ^7.6.0
   go_router: ^13.2.0
-  shared_preferences: ^2.2.2
+  hive: ^2.2.3
+  hive_flutter: ^1.1.0
+  shared_preferences: ^2.2.3
 
 dev_dependencies:
   flutter_test:
@@ -48,6 +50,8 @@ dev_dependencies:
   # package. See that file for information about deactivating specific lint
   # rules and activating additional ones.
   flutter_lints: ^5.0.0
+  build_runner: ^2.4.8
+  hive_generator: ^2.0.1
 
 # For information on the generic Dart part of this file, see the
 # following page: https://dart.dev/tools/pub/pubspec


### PR DESCRIPTION
## Summary
- add Hive packages for local data persistence
- update shared_preferences version
- include generator deps for Hive

## Testing
- `flutter pub get` *(fails: Dart SDK version 3.3.4 < 3.8.1)*

------
https://chatgpt.com/codex/tasks/task_e_68775ce61b3c8329b78b2436ca1ab6e7