### PR TITLE
feat: scaffold HomeScreen

### DIFF
--- a/lib/features/habit/bindings.dart
+++ b/lib/features/habit/bindings.dart
@@ -1,0 +1,10 @@
+import 'package:get_it/get_it.dart';
+
+import 'presentation/controller/home_controller.dart';
+
+class HabitBindings {
+  static void register() {
+    final getIt = GetIt.instance;
+    getIt.registerFactory<HomeController>(HomeController.new);
+  }
+}

--- a/lib/features/habit/presentation/controller/home_controller.dart
+++ b/lib/features/habit/presentation/controller/home_controller.dart
@@ -1,0 +1,5 @@
+import 'package:flutter/foundation.dart';
+
+class HomeController extends ChangeNotifier {
+  // Will hold dashboard streams later
+}

--- a/lib/features/habit/presentation/pages/home_screen.dart
+++ b/lib/features/habit/presentation/pages/home_screen.dart
@@ -1,0 +1,36 @@
+import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+
+import '../../../../routes/app_routes.dart';
+
+class HomeScreen extends StatelessWidget {
+  const HomeScreen({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    final t = Theme.of(context);
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text(
+          'Habit Hero',
+          style: TextStyle(fontWeight: FontWeight.w600),
+        ),
+        leading: IconButton(
+          icon: const Icon(Icons.settings_outlined),
+          tooltip: 'Settings',
+          onPressed: () => context.pushNamed(AppRoutes.settings),
+        ),
+        actions: [
+          IconButton(
+            icon: const Icon(Icons.add_rounded),
+            tooltip: 'New habit',
+            onPressed: () => context.pushNamed(AppRoutes.habitForm),
+          ),
+        ],
+        backgroundColor: t.colorScheme.surface,
+        surfaceTintColor: t.colorScheme.surfaceTint,
+      ),
+      body: const Center(child: Text('Dashboard coming soon')),
+    );
+  }
+}

--- a/lib/features/onboarding/presentation/pages/onboarding_page.dart
+++ b/lib/features/onboarding/presentation/pages/onboarding_page.dart
@@ -2,7 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:get_it/get_it.dart';
 import 'package:go_router/go_router.dart';
 
-import '../../../../routes/app_pages.dart';
+import '../../../../routes/app_routes.dart';
 import '../../../onboarding/presentation/controller/onboarding_controller.dart';
 import '../../../onboarding/presentation/pages/intro_page.dart';
 import '../../../onboarding/presentation/pages/privacy_page.dart';
@@ -52,7 +52,7 @@ class _OnboardingPageState extends State<OnboardingPage> {
                   onPressed: () async {
                     await controller.finish();
                     if (context.mounted) {
-                      context.go(AppPages.home);
+                      context.go(AppRoutes.home);
                     }
                   },
                   child: const Text('Get Started'),

--- a/lib/features/settings/presentation/pages/settings_page.dart
+++ b/lib/features/settings/presentation/pages/settings_page.dart
@@ -1,0 +1,15 @@
+import 'package:flutter/material.dart';
+
+class SettingsPage extends StatelessWidget {
+  const SettingsPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Settings'),
+      ),
+      body: const Center(child: Text('Settings')), 
+    );
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -3,6 +3,7 @@ import 'package:get_it/get_it.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 import 'core/services/theme_service.dart';
+import 'features/habit/bindings.dart';
 import 'features/onboarding/bindings.dart';
 import 'routes/app_pages.dart';
 
@@ -12,6 +13,7 @@ Future<void> main() async {
   GetIt.I.registerSingleton<ThemeService>(ThemeService(prefs));
   await GetIt.I<ThemeService>().init();
   OnboardingBindings.register();
+  HabitBindings.register();
   runApp(const MyApp());
 }
 

--- a/lib/routes/app_pages.dart
+++ b/lib/routes/app_pages.dart
@@ -2,11 +2,12 @@ import 'package:get_it/get_it.dart';
 import 'package:go_router/go_router.dart';
 
 import '../core/services/theme_service.dart';
+import '../features/habit/presentation/pages/home_screen.dart';
 import '../features/onboarding/presentation/pages/onboarding_page.dart';
-import '../main.dart';
+import '../features/settings/presentation/pages/settings_page.dart';
+import '../routes/app_routes.dart';
 
 class AppPages {
-  static const home = '/home';
   static const onboarding = '/onboarding';
 
   static final router = GoRouter(
@@ -15,7 +16,7 @@ class AppPages {
         path: '/',
         redirect: (context, state) {
           final service = GetIt.I<ThemeService>();
-          return service.firstLaunch ? onboarding : home;
+          return service.firstLaunch ? onboarding : AppRoutes.home;
         },
       ),
       GoRoute(
@@ -23,8 +24,19 @@ class AppPages {
         builder: (context, state) => const OnboardingPage(),
       ),
       GoRoute(
-        path: home,
-        builder: (context, state) => const MyHomePage(title: 'Habit Hero'),
+        path: AppRoutes.home,
+        builder: (context, state) => const HomeScreen(),
+      ),
+      GoRoute(
+        path: AppRoutes.settings,
+        builder: (context, state) => const SettingsPage(),
+      ),
+      GoRoute(
+        path: AppRoutes.habitForm,
+        builder: (context, state) => Scaffold(
+          appBar: AppBar(title: const Text('Habit Form')),
+          body: const Center(child: Text('Form coming soon')),
+        ),
       ),
     ],
   );

--- a/lib/routes/app_routes.dart
+++ b/lib/routes/app_routes.dart
@@ -1,0 +1,5 @@
+class AppRoutes {
+  static const home = '/home';
+  static const habitForm = '/habit/form';
+  static const settings = '/settings';
+}

--- a/test/home_screen_golden_test.dart
+++ b/test/home_screen_golden_test.dart
@@ -1,0 +1,13 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:habit_hero_new/features/habit/presentation/pages/home_screen.dart';
+
+void main() {
+  testWidgets('HomeScreen shows settings and add icons', (tester) async {
+    await tester.pumpWidget(const MaterialApp(home: HomeScreen()));
+
+    expect(find.byIcon(Icons.settings_outlined), findsOneWidget);
+    expect(find.byIcon(Icons.add_rounded), findsOneWidget);
+  });
+}


### PR DESCRIPTION
## Summary
- implement HomeScreen with AppBar actions
- wire up HomeController and bindings
- add Settings page stub
- create AppRoutes and update router
- update onboarding flow to navigate to home
- add widget test for HomeScreen

## Testing
- `flutter test` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68775d6af9dc83299c183fc49c10de29