### PR TITLE
Implement HabitKit-style onboarding

### DIFF
--- a/lib/core/constants.dart
+++ b/lib/core/constants.dart
@@ -1,0 +1,5 @@
+const appVersion = '2.0.0';
+
+import 'package:flutter/material.dart';
+
+const accentColor = Color(0xFFBB55FF);

--- a/lib/core/services/theme_service.dart
+++ b/lib/core/services/theme_service.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
+import '../constants.dart';
+
 enum AppTheme { light, dark, highContrast }
 
 class ThemeService extends ChangeNotifier {
@@ -30,17 +32,26 @@ class ThemeService extends ChangeNotifier {
   ThemeData get themeData {
     switch (_theme) {
       case AppTheme.dark:
-        return ThemeData.dark(useMaterial3: true);
+        return ThemeData(
+          useMaterial3: true,
+          colorScheme: ColorScheme.fromSeed(
+            seedColor: accentColor,
+            brightness: Brightness.dark,
+          ),
+        );
       case AppTheme.highContrast:
-
         return ThemeData.from(
-          colorScheme: const ColorScheme.highContrastLight(),
+          colorScheme:
+              const ColorScheme.highContrastLight().copyWith(primary: accentColor),
           useMaterial3: true,
         );
 
       case AppTheme.light:
       default:
-        return ThemeData(useMaterial3: true, colorSchemeSeed: Colors.deepPurple);
+        return ThemeData(
+          useMaterial3: true,
+          colorScheme: ColorScheme.fromSeed(seedColor: accentColor),
+        );
     }
   }
 

--- a/lib/core/services/user_prefs_service.dart
+++ b/lib/core/services/user_prefs_service.dart
@@ -1,0 +1,38 @@
+import 'package:flutter/material.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+class UserPrefsService extends ChangeNotifier {
+  UserPrefsService(this._prefs);
+
+  static const _firstLaunchKey = 'firstLaunch';
+  static const _versionKey = 'appVersionSeen';
+
+  final SharedPreferences _prefs;
+
+  bool _firstLaunch = true;
+  String? _appVersionSeen;
+
+  Future<void> init() async {
+    _firstLaunch = _prefs.getBool(_firstLaunchKey) ?? true;
+    _appVersionSeen = _prefs.getString(_versionKey);
+  }
+
+  bool get firstLaunch => _firstLaunch;
+  String? get appVersionSeen => _appVersionSeen;
+
+  set firstLaunch(bool value) {
+    _firstLaunch = value;
+    _prefs.setBool(_firstLaunchKey, value);
+    notifyListeners();
+  }
+
+  set appVersionSeen(String? value) {
+    _appVersionSeen = value;
+    if (value == null) {
+      _prefs.remove(_versionKey);
+    } else {
+      _prefs.setString(_versionKey, value);
+    }
+    notifyListeners();
+  }
+}

--- a/lib/features/onboarding/bindings.dart
+++ b/lib/features/onboarding/bindings.dart
@@ -1,10 +1,13 @@
 import 'package:get_it/get_it.dart';
 
 import 'presentation/controller/onboarding_controller.dart';
+import '../core/services/user_prefs_service.dart';
 
 class OnboardingBindings {
   static void register() {
     final getIt = GetIt.instance;
-    getIt.registerFactory<OnboardingController>(OnboardingController.new);
+    getIt.registerFactory<OnboardingController>(
+      () => OnboardingController(getIt<UserPrefsService>()),
+    );
   }
 }

--- a/lib/features/onboarding/presentation/controller/onboarding_controller.dart
+++ b/lib/features/onboarding/presentation/controller/onboarding_controller.dart
@@ -1,25 +1,32 @@
 import 'package:flutter/material.dart';
 import 'package:get_it/get_it.dart';
+import 'package:go_router/go_router.dart';
 
+import '../../../../core/constants.dart';
 import '../../../../core/services/theme_service.dart';
+import '../../../../core/services/user_prefs_service.dart';
+import '../../../../routes/app_routes.dart';
 
 class OnboardingController extends ChangeNotifier {
-  OnboardingController() : _themeService = GetIt.I<ThemeService>();
+  OnboardingController(this._prefs) : _themeService = GetIt.I<ThemeService>();
 
+  final UserPrefsService _prefs;
   final ThemeService _themeService;
-  final PageController pageController = PageController();
-  int currentPage = 0;
 
-  void nextPage() {
-    if (currentPage < 2) {
-      currentPage++;
-      pageController.animateToPage(
-        currentPage,
-        duration: const Duration(milliseconds: 300),
-        curve: Curves.easeInOut,
-      );
-      notifyListeners();
+  int _index = 0;
+  int get index => _index;
+
+  AppTheme get theme => _themeService.theme;
+
+  bool get showWhatsNew => _prefs.appVersionSeen != appVersion;
+
+  void next(BuildContext ctx) {
+    if (_index == 0 && showWhatsNew) {
+      _index = 1;
+    } else if ((_index == 0 && !showWhatsNew) || _index == 1) {
+      ctx.goNamed(AppRoutes.themeChoice);
     }
+    notifyListeners();
   }
 
   void selectTheme(AppTheme theme) {
@@ -27,9 +34,10 @@ class OnboardingController extends ChangeNotifier {
     notifyListeners();
   }
 
-  Future<void> finish() async {
-    await _themeService.setFirstLaunchFalse();
+  void finish(BuildContext ctx) {
+    _prefs
+      ..firstLaunch = false
+      ..appVersionSeen = appVersion;
+    ctx.goNamed(AppRoutes.home);
   }
-
-  AppTheme get theme => _themeService.theme;
 }

--- a/lib/features/onboarding/presentation/pages/theme_choice_page.dart
+++ b/lib/features/onboarding/presentation/pages/theme_choice_page.dart
@@ -1,25 +1,30 @@
 import 'package:flutter/material.dart';
 
+import 'package:get_it/get_it.dart';
+
 import '../../../../core/services/theme_service.dart';
 import '../controller/onboarding_controller.dart';
 
 class ThemeChoicePage extends StatelessWidget {
-  const ThemeChoicePage({super.key, required this.controller});
-
-  final OnboardingController controller;
+  const ThemeChoicePage({super.key});
 
   @override
   Widget build(BuildContext context) {
+    final controller = GetIt.I<OnboardingController>();
     final theme = controller.theme;
-    return Padding(
-      padding: const EdgeInsets.all(24),
-      child: Column(
-        children: [
-          const Spacer(),
-          Text(
-            'Choose your theme',
-            style: Theme.of(context).textTheme.headlineMedium,
-          ),
+    return Scaffold(
+      appBar: AppBar(
+        leading: BackButton(onPressed: () => Navigator.of(context).pop()),
+      ),
+      body: Padding(
+        padding: const EdgeInsets.all(24),
+        child: Column(
+          children: [
+            const Spacer(),
+            Text(
+              'Choose your theme',
+              style: Theme.of(context).textTheme.headlineMedium,
+            ),
           const SizedBox(height: 24),
           Row(
             mainAxisAlignment: MainAxisAlignment.spaceEvenly,
@@ -35,10 +40,11 @@ class ThemeChoicePage extends StatelessWidget {
           ),
           const Spacer(),
           ElevatedButton(
-            onPressed: controller.finish,
+            onPressed: () => controller.finish(context),
             child: const Text('Get Started'),
           ),
         ],
+      ),
       ),
     );
   }

--- a/lib/features/onboarding/presentation/pages/welcome_page.dart
+++ b/lib/features/onboarding/presentation/pages/welcome_page.dart
@@ -1,0 +1,114 @@
+import 'package:flutter/material.dart';
+import 'package:get_it/get_it.dart';
+
+import '../../presentation/controller/onboarding_controller.dart';
+
+class WelcomePage extends StatelessWidget {
+  const WelcomePage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final controller = GetIt.I<OnboardingController>();
+    final theme = Theme.of(context);
+    return Container(
+      decoration: const BoxDecoration(
+        gradient: LinearGradient(
+          begin: Alignment.topCenter,
+          end: Alignment.bottomCenter,
+          colors: [Color(0xFF0E0E0E), Color(0xFF111827)],
+        ),
+      ),
+      child: SafeArea(
+        child: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 24),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              const SizedBox(height: 32),
+              RichText(
+                text: TextSpan(
+                  style: theme.textTheme.headlineSmall,
+                  children: [
+                    const TextSpan(text: 'Welcome to '),
+                    TextSpan(
+                      text: 'HabitHero',
+                      style: TextStyle(color: theme.colorScheme.primary),
+                    ),
+                  ],
+                ),
+              ),
+              const SizedBox(height: 16),
+              const _FeatureTile(
+                icon: Icons.check_circle_outline,
+                title: 'Track Habits',
+                subtitle: 'Monitor your daily progress',
+              ),
+              const _FeatureTile(
+                icon: Icons.alarm,
+                title: 'Reminders',
+                subtitle: 'Never forget a habit',
+              ),
+              const _FeatureTile(
+                icon: Icons.bar_chart,
+                title: 'Statistics',
+                subtitle: 'Visualize improvement',
+              ),
+              const _FeatureTile(
+                icon: Icons.stacked_line_chart,
+                title: 'Streaks',
+                subtitle: 'Stay motivated every day',
+              ),
+              const _FeatureTile(
+                icon: Icons.flag,
+                title: 'Goals',
+                subtitle: 'Set achievable targets',
+              ),
+              const _FeatureTile(
+                icon: Icons.widgets,
+                title: 'Widgets',
+                subtitle: 'Quick access on home',
+              ),
+              const _FeatureTile(
+                icon: Icons.dark_mode,
+                title: 'Dark Mode',
+                subtitle: 'Easy on the eyes',
+              ),
+              const _FeatureTile(
+                icon: Icons.privacy_tip,
+                title: 'Privacy',
+                subtitle: 'Your data stays local',
+              ),
+              const Spacer(),
+              FilledButton(
+                onPressed: () => controller.next(context),
+                child: const Text('Continue'),
+              ),
+              const SizedBox(height: 16),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _FeatureTile extends StatelessWidget {
+  const _FeatureTile({
+    required this.icon,
+    required this.title,
+    required this.subtitle,
+  });
+
+  final IconData icon;
+  final String title;
+  final String subtitle;
+
+  @override
+  Widget build(BuildContext context) {
+    return ListTile(
+      leading: Icon(icon, color: Theme.of(context).colorScheme.primary),
+      title: Text(title),
+      subtitle: Text(subtitle),
+    );
+  }
+}

--- a/lib/features/onboarding/presentation/pages/whats_new_page.dart
+++ b/lib/features/onboarding/presentation/pages/whats_new_page.dart
@@ -1,0 +1,96 @@
+import 'dart:ui';
+
+import 'package:flutter/material.dart';
+import 'package:get_it/get_it.dart';
+
+import '../../controller/onboarding_controller.dart';
+
+class WhatsNewPage extends StatelessWidget {
+  const WhatsNewPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final controller = GetIt.I<OnboardingController>();
+    return Scaffold(
+      body: SafeArea(
+        child: Padding(
+          padding: const EdgeInsets.all(24),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              SizedBox(
+                height: 220,
+                child: Stack(
+                  children: [
+                    Align(
+                      alignment: const Alignment(-0.4, -0.2),
+                      child: Icon(Icons.smartphone, size: 160, color: Colors.grey.withOpacity(0.4)),
+                    ),
+                    Align(
+                      alignment: const Alignment(0.4, 0.2),
+                      child: Icon(Icons.smartphone, size: 160, color: Colors.grey.withOpacity(0.4)),
+                    ),
+                  ],
+                ),
+              ),
+              Container(
+                padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+                decoration: BoxDecoration(
+                  color: Theme.of(context).colorScheme.primary,
+                  borderRadius: BorderRadius.circular(8),
+                ),
+                child: const Text(
+                  'MAJOR UPDATE',
+                  style: TextStyle(color: Colors.white),
+                ),
+              ),
+              const SizedBox(height: 16),
+              Text(
+                'New Habit Detail View',
+                style: Theme.of(context).textTheme.headlineSmall,
+              ),
+              const SizedBox(height: 8),
+              const Text(
+                'Experience a redesigned habit view with improved interactions.',
+              ),
+              const SizedBox(height: 16),
+              const _FeatureTile(
+                icon: Icons.event,
+                title: 'Integrated Calendar',
+              ),
+              const _FeatureTile(
+                icon: Icons.list_alt,
+                title: 'Compact List',
+              ),
+              const _FeatureTile(
+                icon: Icons.bug_report,
+                title: 'Bugfixes',
+              ),
+              const Spacer(),
+              FilledButton(
+                onPressed: () => controller.next(context),
+                child: const Text('Continue'),
+              ),
+              const SizedBox(height: 16),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _FeatureTile extends StatelessWidget {
+  const _FeatureTile({required this.icon, required this.title});
+
+  final IconData icon;
+  final String title;
+
+  @override
+  Widget build(BuildContext context) {
+    return ListTile(
+      leading: Icon(icon, color: Theme.of(context).colorScheme.primary),
+      title: Text(title),
+    );
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -3,6 +3,7 @@ import 'package:get_it/get_it.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 import 'core/services/theme_service.dart';
+import 'core/services/user_prefs_service.dart';
 import 'features/habit/bindings.dart';
 import 'features/onboarding/bindings.dart';
 import 'routes/app_pages.dart';
@@ -10,6 +11,10 @@ import 'routes/app_pages.dart';
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
   final prefs = await SharedPreferences.getInstance();
+  final userPrefs = UserPrefsService(prefs);
+  await userPrefs.init();
+  GetIt.I.registerSingleton<UserPrefsService>(userPrefs);
+
   GetIt.I.registerSingleton<ThemeService>(ThemeService(prefs));
   await GetIt.I<ThemeService>().init();
   OnboardingBindings.register();

--- a/lib/routes/app_pages.dart
+++ b/lib/routes/app_pages.dart
@@ -2,39 +2,52 @@ import 'package:flutter/material.dart';
 import 'package:get_it/get_it.dart';
 import 'package:go_router/go_router.dart';
 
-import '../core/services/theme_service.dart';
+import '../core/constants.dart';
+import '../core/services/user_prefs_service.dart';
 import '../features/habit/presentation/pages/home_screen.dart';
-import '../features/onboarding/presentation/pages/onboarding_page.dart';
+import '../features/onboarding/presentation/pages/theme_choice_page.dart';
+import '../features/onboarding/presentation/pages/welcome_page.dart';
+import '../features/onboarding/presentation/pages/whats_new_page.dart';
 import '../features/settings/presentation/pages/settings_page.dart';
 import '../routes/app_routes.dart';
 
 class AppPages {
-  static const onboarding = '/onboarding';
-
   static final router = GoRouter(
     routes: [
       GoRoute(
         path: '/',
         redirect: (context, state) {
-          final service = GetIt.I<ThemeService>();
-          return service.firstLaunch ? onboarding : AppRoutes.home;
+          final prefs = GetIt.I<UserPrefsService>();
+          if (prefs.firstLaunch) return AppRoutes.onboardingWelcome;
+          if (prefs.appVersionSeen != appVersion) {
+            return AppRoutes.onboardingWhatsNew;
+          }
+          return AppRoutes.home;
         },
       ),
       GoRoute(
-        path: onboarding,
-        builder: (context, state) => const OnboardingPage(),
+        path: AppRoutes.onboardingWelcome,
+        builder: (_, __) => const WelcomePage(),
+      ),
+      GoRoute(
+        path: AppRoutes.onboardingWhatsNew,
+        builder: (_, __) => const WhatsNewPage(),
+      ),
+      GoRoute(
+        path: AppRoutes.themeChoice,
+        builder: (_, __) => const ThemeChoicePage(),
       ),
       GoRoute(
         path: AppRoutes.home,
-        builder: (context, state) => const HomeScreen(),
+        builder: (_, __) => const HomeScreen(),
       ),
       GoRoute(
         path: AppRoutes.settings,
-        builder: (context, state) => const SettingsPage(),
+        builder: (_, __) => const SettingsPage(),
       ),
       GoRoute(
         path: AppRoutes.habitForm,
-        builder: (context, state) => Scaffold(
+        builder: (_, __) => Scaffold(
           appBar: AppBar(title: const Text('Habit Form')),
           body: const Center(child: Text('Form coming soon')),
         ),

--- a/lib/routes/app_routes.dart
+++ b/lib/routes/app_routes.dart
@@ -2,4 +2,7 @@ class AppRoutes {
   static const home = '/home';
   static const habitForm = '/habit/form';
   static const settings = '/settings';
+  static const onboardingWelcome = '/onboard/welcome';
+  static const onboardingWhatsNew = '/onboard/whatsnew';
+  static const themeChoice = '/onboard/theme';
 }

--- a/test/onboarding_controller_test.dart
+++ b/test/onboarding_controller_test.dart
@@ -1,27 +1,35 @@
+import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:get_it/get_it.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
-import 'package:get_it/get_it.dart';
 import 'package:habit_hero_new/core/services/theme_service.dart';
+import 'package:habit_hero_new/core/services/user_prefs_service.dart';
 import 'package:habit_hero_new/features/onboarding/presentation/controller/onboarding_controller.dart';
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
   late OnboardingController controller;
+  late UserPrefsService prefs;
 
   setUp(() async {
     SharedPreferences.setMockInitialValues({});
-    final prefs = await SharedPreferences.getInstance();
-    final themeService = ThemeService(prefs);
+    final shared = await SharedPreferences.getInstance();
+    prefs = UserPrefsService(shared);
+    await prefs.init();
+    final themeService = ThemeService(shared);
     await themeService.init();
     GetIt.I.registerSingleton<ThemeService>(themeService);
-    controller = OnboardingController();
+    GetIt.I.registerSingleton<UserPrefsService>(prefs);
+    controller = OnboardingController(prefs);
   });
 
-  test('nextPage increments currentPage', () {
-    expect(controller.currentPage, 0);
-    controller.nextPage();
-    expect(controller.currentPage, 1);
+  testWidgets('next increments index when showing whats new', (tester) async {
+    await tester.pumpWidget(Builder(builder: (context) {
+      controller.next(context);
+      return Container();
+    }));
+    expect(controller.index, 1);
   });
 }


### PR DESCRIPTION
## Summary
- add global constants for app version and accent color
- implement UserPrefsService for onboarding preferences
- overhaul OnboardingController and new onboarding pages
- update theme with accent color support
- wire new routes and bindings
- test onboarding controller behavior

## Testing
- `apt-get update`
- `apt-get install -y dart` *(fails: package not found)*
- `apt-get install -y flutter` *(fails: package not found)*

------
https://chatgpt.com/codex/tasks/task_e_68776fd029f48329a8831c0736786ece