### PR TITLE
Add HabitKit-style home screen

### DIFF
--- a/lib/features/habit/bindings.dart
+++ b/lib/features/habit/bindings.dart
@@ -1,10 +1,12 @@
 import 'package:get_it/get_it.dart';
 
 import 'presentation/controller/home_controller.dart';
+import 'presentation/controller/habit_controller.dart';
 
 class HabitBindings {
   static void register() {
     final getIt = GetIt.instance;
+    getIt.registerLazySingleton<HabitController>(HabitController.new);
     getIt.registerFactory<HomeController>(HomeController.new);
   }
 }

--- a/lib/features/habit/domain/entities/habit.dart
+++ b/lib/features/habit/domain/entities/habit.dart
@@ -1,0 +1,7 @@
+class Habit {
+  final String id;
+  final String title;
+  final String? description;
+
+  Habit({required this.id, required this.title, this.description});
+}

--- a/lib/features/habit/presentation/controller/habit_controller.dart
+++ b/lib/features/habit/presentation/controller/habit_controller.dart
@@ -1,0 +1,14 @@
+import 'package:flutter/foundation.dart';
+
+import '../../domain/entities/habit.dart';
+
+class HabitController extends ChangeNotifier {
+  final List<Habit> _habits = [];
+
+  List<Habit> get habits => List.unmodifiable(_habits);
+
+  void addHabit(Habit habit) {
+    _habits.add(habit);
+    notifyListeners();
+  }
+}

--- a/lib/features/habit/presentation/pages/habit_list_page.dart
+++ b/lib/features/habit/presentation/pages/habit_list_page.dart
@@ -1,0 +1,20 @@
+import 'package:flutter/material.dart';
+
+import '../../domain/entities/habit.dart';
+
+class HabitListPage extends StatelessWidget {
+  final List<Habit> habits;
+
+  const HabitListPage({super.key, required this.habits});
+
+  @override
+  Widget build(BuildContext context) {
+    return ListView.builder(
+      itemCount: habits.length,
+      itemBuilder: (context, index) {
+        final habit = habits[index];
+        return ListTile(title: Text(habit.title));
+      },
+    );
+  }
+}

--- a/lib/features/habit/presentation/pages/home_screen.dart
+++ b/lib/features/habit/presentation/pages/home_screen.dart
@@ -1,36 +1,59 @@
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
+import 'package:provider/provider.dart';
 
 import '../../../../routes/app_routes.dart';
+import '../controller/habit_controller.dart';
+import 'habit_list_page.dart';
+import '../widgets/empty_state.dart';
 
 class HomeScreen extends StatelessWidget {
-  const HomeScreen({Key? key}) : super(key: key);
+  const HomeScreen({super.key});
 
   @override
   Widget build(BuildContext context) {
-    final t = Theme.of(context);
+    final controller = context.watch<HabitController>();
+
     return Scaffold(
       appBar: AppBar(
-        title: const Text(
-          'Habit Hero',
-          style: TextStyle(fontWeight: FontWeight.w600),
-        ),
         leading: IconButton(
           icon: const Icon(Icons.settings_outlined),
           tooltip: 'Settings',
           onPressed: () => context.pushNamed(AppRoutes.settings),
         ),
+        title: RichText(
+          text: TextSpan(
+            style: Theme.of(context).textTheme.titleLarge,
+            children: const [
+              TextSpan(text: 'Habit'),
+              TextSpan(
+                text: 'Hero',
+                style: TextStyle(color: Color(0xFFBB55FF)),
+              ),
+            ],
+          ),
+        ),
         actions: [
           IconButton(
-            icon: const Icon(Icons.add_rounded),
+            icon: const Icon(Icons.show_chart_outlined),
+            tooltip: 'Statistics',
+            onPressed: () => context.pushNamed(AppRoutes.stats),
+          ),
+          IconButton(
+            icon: const Icon(Icons.add_circle_outline),
             tooltip: 'New habit',
             onPressed: () => context.pushNamed(AppRoutes.habitForm),
           ),
         ],
-        backgroundColor: t.colorScheme.surface,
-        surfaceTintColor: t.colorScheme.surfaceTint,
+        backgroundColor: Theme.of(context).colorScheme.surface,
+        surfaceTintColor: Theme.of(context).colorScheme.surfaceTint,
       ),
-      body: const Center(child: Text('Dashboard coming soon')),
+      body: AnimatedSwitcher(
+        duration: const Duration(milliseconds: 300),
+        child: controller.habits.isEmpty
+            ? const EmptyStateWidget()
+            : HabitListPage(habits: controller.habits),
+      ),
     );
   }
 }

--- a/lib/features/habit/presentation/widgets/empty_state.dart
+++ b/lib/features/habit/presentation/widgets/empty_state.dart
@@ -1,0 +1,42 @@
+import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+
+import '../../../../routes/app_routes.dart';
+
+class EmptyStateWidget extends StatelessWidget {
+  const EmptyStateWidget({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final accent = const Color(0xFFBB55FF);
+    return Center(
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Container(
+            decoration: BoxDecoration(
+              border: Border.all(color: accent, width: 2),
+              shape: BoxShape.circle,
+            ),
+            padding: const EdgeInsets.all(16),
+            child: Icon(Icons.add, size: 48, color: accent),
+          ),
+          const SizedBox(height: 24),
+          Text('No habit found', style: Theme.of(context).textTheme.titleLarge),
+          const SizedBox(height: 8),
+          Text(
+            'Create a new habit to track your progress',
+            style: Theme.of(context).textTheme.bodyMedium,
+            textAlign: TextAlign.center,
+          ),
+          const SizedBox(height: 24),
+          FilledButton(
+            style: FilledButton.styleFrom(backgroundColor: accent),
+            onPressed: () => context.pushNamed(AppRoutes.habitForm),
+            child: const Text('Get started'),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/features/stats/presentation/pages/stats_page.dart
+++ b/lib/features/stats/presentation/pages/stats_page.dart
@@ -1,0 +1,13 @@
+import 'package:flutter/material.dart';
+
+class StatsPage extends StatelessWidget {
+  const StatsPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Statistics')),
+      body: const Center(child: Text('Stats')),
+    );
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,10 +1,12 @@
 import 'package:flutter/material.dart';
 import 'package:get_it/get_it.dart';
 import 'package:shared_preferences/shared_preferences.dart';
+import 'package:provider/provider.dart';
 
 import 'core/services/theme_service.dart';
 import 'core/services/user_prefs_service.dart';
 import 'features/habit/bindings.dart';
+import 'features/habit/presentation/controller/habit_controller.dart';
 import 'features/onboarding/bindings.dart';
 import 'routes/app_pages.dart';
 
@@ -31,10 +33,13 @@ class MyApp extends StatelessWidget {
     return AnimatedBuilder(
       animation: themeService,
       builder: (context, _) {
-        return MaterialApp.router(
-          title: 'Habit Hero',
-          routerConfig: AppPages.router,
-          theme: themeService.themeData,
+        return ChangeNotifierProvider(
+          create: (_) => GetIt.I<HabitController>(),
+          child: MaterialApp.router(
+            title: 'Habit Hero',
+            routerConfig: AppPages.router,
+            theme: themeService.themeData,
+          ),
         );
       },
     );

--- a/lib/routes/app_pages.dart
+++ b/lib/routes/app_pages.dart
@@ -9,6 +9,7 @@ import '../features/onboarding/presentation/pages/theme_choice_page.dart';
 import '../features/onboarding/presentation/pages/welcome_page.dart';
 import '../features/onboarding/presentation/pages/whats_new_page.dart';
 import '../features/settings/presentation/pages/settings_page.dart';
+import '../features/stats/presentation/pages/stats_page.dart';
 import '../routes/app_routes.dart';
 
 class AppPages {
@@ -39,11 +40,16 @@ class AppPages {
       ),
       GoRoute(
         path: AppRoutes.home,
+        name: AppRoutes.home,
         builder: (_, __) => const HomeScreen(),
       ),
       GoRoute(
         path: AppRoutes.settings,
         builder: (_, __) => const SettingsPage(),
+      ),
+      GoRoute(
+        path: AppRoutes.stats,
+        builder: (_, __) => const StatsPage(),
       ),
       GoRoute(
         path: AppRoutes.habitForm,

--- a/lib/routes/app_routes.dart
+++ b/lib/routes/app_routes.dart
@@ -1,7 +1,8 @@
 class AppRoutes {
   static const home = '/home';
-  static const habitForm = '/habit/form';
   static const settings = '/settings';
+  static const habitForm = '/habit/form';
+  static const stats = '/stats';
   static const onboardingWelcome = '/onboard/welcome';
   static const onboardingWhatsNew = '/onboard/whatsnew';
   static const themeChoice = '/onboard/theme';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -36,6 +36,7 @@ dependencies:
   cupertino_icons: ^1.0.8
   get_it: ^7.6.0
   go_router: ^13.2.0
+  provider: ^6.0.5
   hive: ^2.2.3
   hive_flutter: ^1.1.0
   shared_preferences: ^2.2.3

--- a/test/home_navigation_test.dart
+++ b/test/home_navigation_test.dart
@@ -1,15 +1,15 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
-
 import 'package:go_router/go_router.dart';
 import 'package:provider/provider.dart';
+
 import 'package:habit_hero_new/features/habit/presentation/controller/habit_controller.dart';
 import 'package:habit_hero_new/features/habit/presentation/pages/home_screen.dart';
-import 'package:habit_hero_new/routes/app_routes.dart';
 import 'package:habit_hero_new/features/settings/presentation/pages/settings_page.dart';
+import 'package:habit_hero_new/routes/app_routes.dart';
 
 void main() {
-  testWidgets('HomeScreen shows settings and add icons', (tester) async {
+  testWidgets('tapping settings navigates to SettingsPage', (tester) async {
     final router = GoRouter(
       routes: [
         GoRoute(
@@ -22,6 +22,7 @@ void main() {
         ),
       ],
     );
+
     await tester.pumpWidget(
       ChangeNotifierProvider(
         create: (_) => HabitController(),
@@ -29,7 +30,9 @@ void main() {
       ),
     );
 
-    expect(find.byIcon(Icons.settings_outlined), findsOneWidget);
-    expect(find.byIcon(Icons.add_circle_outline), findsOneWidget);
+    await tester.tap(find.byTooltip('Settings'));
+    await tester.pumpAndSettle();
+
+    expect(find.byType(SettingsPage), findsOneWidget);
   });
 }

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -7,10 +7,28 @@
 
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:get_it/get_it.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:habit_hero_new/core/services/theme_service.dart';
+import 'package:habit_hero_new/core/services/user_prefs_service.dart';
 
 import 'package:habit_hero_new/main.dart';
 
 void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() async {
+    SharedPreferences.setMockInitialValues({});
+    final shared = await SharedPreferences.getInstance();
+    final themeService = ThemeService(shared);
+    await themeService.init();
+    final prefs = UserPrefsService(shared);
+    await prefs.init();
+    GetIt.I.registerSingleton<ThemeService>(themeService);
+    GetIt.I.registerSingleton<UserPrefsService>(prefs);
+  });
+
   testWidgets('Counter increments smoke test', (WidgetTester tester) async {
     // Build our app and trigger a frame.
     await tester.pumpWidget(const MyApp());


### PR DESCRIPTION
## Summary
- add Habit entity and controller
- implement HabitListPage and EmptyStateWidget
- create StatsPage stub
- wire up Habit routes and update app pages
- update HomeScreen with navigation and animated empty state
- register HabitController and provide it via MyApp
- add provider dependency and update tests
- add new navigation test for home screen

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68777318944c83298f80cb529c191770