### PR TITLE
Fix onboarding imports and controller

### DIFF
--- a/lib/features/onboarding/bindings.dart
+++ b/lib/features/onboarding/bindings.dart
@@ -1,7 +1,7 @@
 import 'package:get_it/get_it.dart';
 
 import 'presentation/controller/onboarding_controller.dart';
-import '../core/services/user_prefs_service.dart';
+import '../../core/services/user_prefs_service.dart';
 
 class OnboardingBindings {
   static void register() {

--- a/lib/features/onboarding/presentation/controller/onboarding_controller.dart
+++ b/lib/features/onboarding/presentation/controller/onboarding_controller.dart
@@ -13,13 +13,20 @@ class OnboardingController extends ChangeNotifier {
   final UserPrefsService _prefs;
   final ThemeService _themeService;
 
+  final PageController pageController = PageController();
   int _index = 0;
+
+  /// Exposed for tests that rely on the old API
   int get index => _index;
+
+  /// Current page in the onboarding [PageView].
+  int get currentPage => _index;
 
   AppTheme get theme => _themeService.theme;
 
   bool get showWhatsNew => _prefs.appVersionSeen != appVersion;
 
+  /// Used by the old welcome/whats new pages to proceed to the next step.
   void next(BuildContext ctx) {
     if (_index == 0 && showWhatsNew) {
       _index = 1;
@@ -29,15 +36,34 @@ class OnboardingController extends ChangeNotifier {
     notifyListeners();
   }
 
+  /// Advances the page view to the next page.
+  void nextPage() {
+    if (_index < 2) {
+      _index++;
+      pageController.animateToPage(
+        _index,
+        duration: const Duration(milliseconds: 300),
+        curve: Curves.easeInOut,
+      );
+      notifyListeners();
+    }
+  }
+
   void selectTheme(AppTheme theme) {
     _themeService.toggleTheme(theme);
     notifyListeners();
   }
 
-  void finish(BuildContext ctx) {
+  /// Completes onboarding and saves user preferences.
+  Future<void> finish() async {
     _prefs
       ..firstLaunch = false
       ..appVersionSeen = appVersion;
-    ctx.goNamed(AppRoutes.home);
+  }
+
+  @override
+  void dispose() {
+    pageController.dispose();
+    super.dispose();
   }
 }


### PR DESCRIPTION
## Summary
- fix incorrect import path in onboarding bindings
- implement `nextPage`, `finish` and page management in onboarding controller

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6877750656c88329ac0952aaa2785800