### PR TITLE
Fix onboarding pages

### DIFF
--- a/lib/features/onboarding/presentation/pages/theme_choice_page.dart
+++ b/lib/features/onboarding/presentation/pages/theme_choice_page.dart
@@ -1,16 +1,21 @@
 import 'package:flutter/material.dart';
 
-import 'package:get_it/get_it.dart';
+import 'package:go_router/go_router.dart';
 
 import '../../../../core/services/theme_service.dart';
+import '../../../../routes/app_routes.dart';
 import '../controller/onboarding_controller.dart';
 
 class ThemeChoicePage extends StatelessWidget {
-  const ThemeChoicePage({super.key});
+  const ThemeChoicePage({
+    super.key,
+    required this.controller,
+  });
+
+  final OnboardingController controller;
 
   @override
   Widget build(BuildContext context) {
-    final controller = GetIt.I<OnboardingController>();
     final theme = controller.theme;
     return Scaffold(
       appBar: AppBar(
@@ -40,7 +45,12 @@ class ThemeChoicePage extends StatelessWidget {
           ),
           const Spacer(),
           ElevatedButton(
-            onPressed: () => controller.finish(context),
+            onPressed: () async {
+              await controller.finish();
+              if (context.mounted) {
+                context.go(AppRoutes.home);
+              }
+            },
             child: const Text('Get Started'),
           ),
         ],

--- a/lib/features/onboarding/presentation/pages/whats_new_page.dart
+++ b/lib/features/onboarding/presentation/pages/whats_new_page.dart
@@ -3,7 +3,7 @@ import 'dart:ui';
 import 'package:flutter/material.dart';
 import 'package:get_it/get_it.dart';
 
-import '../../controller/onboarding_controller.dart';
+import '../controller/onboarding_controller.dart';
 
 class WhatsNewPage extends StatelessWidget {
   const WhatsNewPage({super.key});

--- a/lib/routes/app_pages.dart
+++ b/lib/routes/app_pages.dart
@@ -6,6 +6,7 @@ import '../core/constants.dart';
 import '../core/services/user_prefs_service.dart';
 import '../features/habit/presentation/pages/home_screen.dart';
 import '../features/onboarding/presentation/pages/theme_choice_page.dart';
+import '../features/onboarding/presentation/controller/onboarding_controller.dart';
 import '../features/onboarding/presentation/pages/welcome_page.dart';
 import '../features/onboarding/presentation/pages/whats_new_page.dart';
 import '../features/settings/presentation/pages/settings_page.dart';
@@ -36,7 +37,9 @@ class AppPages {
       ),
       GoRoute(
         path: AppRoutes.themeChoice,
-        builder: (_, __) => const ThemeChoicePage(),
+        builder: (_, __) => ThemeChoicePage(
+          controller: GetIt.I<OnboardingController>(),
+        ),
       ),
       GoRoute(
         path: AppRoutes.home,


### PR DESCRIPTION
## Summary
- allow ThemeChoicePage to receive OnboardingController
- fix import path in WhatsNewPage
- wire controller into router when loading the ThemeChoicePage

## Testing
- `apt-get update`
- `apt-get install -y dart` *(fails: package not found)*
- `apt-get install -y flutter` *(fails: package not found)*

------
https://chatgpt.com/codex/tasks/task_e_6877774626b083298dfc131d6c5a757d