### PR TITLE
fix: wrap onboarding pages in Scaffold

### DIFF
--- a/lib/features/onboarding/presentation/pages/theme_choice_page.dart
+++ b/lib/features/onboarding/presentation/pages/theme_choice_page.dart
@@ -7,10 +7,7 @@ import '../../../../routes/app_routes.dart';
 import '../controller/onboarding_controller.dart';
 
 class ThemeChoicePage extends StatelessWidget {
-  const ThemeChoicePage({
-    super.key,
-    required this.controller,
-  });
+  const ThemeChoicePage({super.key, required this.controller});
 
   final OnboardingController controller;
 
@@ -21,40 +18,42 @@ class ThemeChoicePage extends StatelessWidget {
       appBar: AppBar(
         leading: BackButton(onPressed: () => Navigator.of(context).pop()),
       ),
-      body: Padding(
-        padding: const EdgeInsets.all(24),
-        child: Column(
-          children: [
-            const Spacer(),
-            Text(
-              'Choose your theme',
-              style: Theme.of(context).textTheme.headlineMedium,
-            ),
-          const SizedBox(height: 24),
-          Row(
-            mainAxisAlignment: MainAxisAlignment.spaceEvenly,
-            children: AppTheme.values
-                .map(
-                  (t) => _ThemeCard(
-                    title: t.name,
-                    selected: theme == t,
-                    onTap: () => controller.selectTheme(t),
-                  ),
-                )
-                .toList(),
+      body: SafeArea(
+        child: Padding(
+          padding: const EdgeInsets.all(24),
+          child: Column(
+            children: [
+              const Spacer(),
+              Text(
+                'Choose your theme',
+                style: Theme.of(context).textTheme.headlineMedium,
+              ),
+              const SizedBox(height: 24),
+              Row(
+                mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+                children: AppTheme.values
+                    .map(
+                      (t) => _ThemeCard(
+                        title: t.name,
+                        selected: theme == t,
+                        onTap: () => controller.selectTheme(t),
+                      ),
+                    )
+                    .toList(),
+              ),
+              const Spacer(),
+              ElevatedButton(
+                onPressed: () async {
+                  await controller.finish();
+                  if (context.mounted) {
+                    context.go(AppRoutes.home);
+                  }
+                },
+                child: const Text('Get Started'),
+              ),
+            ],
           ),
-          const Spacer(),
-          ElevatedButton(
-            onPressed: () async {
-              await controller.finish();
-              if (context.mounted) {
-                context.go(AppRoutes.home);
-              }
-            },
-            child: const Text('Get Started'),
-          ),
-        ],
-      ),
+        ),
       ),
     );
   }

--- a/lib/features/onboarding/presentation/pages/welcome_page.dart
+++ b/lib/features/onboarding/presentation/pages/welcome_page.dart
@@ -9,85 +9,98 @@ class WelcomePage extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final controller = GetIt.I<OnboardingController>();
-    final theme = Theme.of(context);
-    return Container(
-      decoration: const BoxDecoration(
-        gradient: LinearGradient(
-          begin: Alignment.topCenter,
-          end: Alignment.bottomCenter,
-          colors: [Color(0xFF0E0E0E), Color(0xFF111827)],
+    return Scaffold(
+      extendBodyBehindAppBar: true,
+      backgroundColor: Colors.transparent,
+      body: Container(
+        decoration: const BoxDecoration(
+          gradient: LinearGradient(
+            begin: Alignment.topCenter,
+            end: Alignment.bottomCenter,
+            colors: [Color(0xFF0E0E0E), Color(0xFF111827)],
+          ),
+        ),
+        padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 48),
+        child: SingleChildScrollView(
+          child: _FeatureList(controller: controller),
         ),
       ),
-      child: SafeArea(
-        child: Padding(
-          padding: const EdgeInsets.symmetric(horizontal: 24),
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
+    );
+  }
+}
+
+class _FeatureList extends StatelessWidget {
+  const _FeatureList({required this.controller});
+
+  final OnboardingController controller;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        const SizedBox(height: 32),
+        RichText(
+          text: TextSpan(
+            style: theme.textTheme.headlineSmall,
             children: [
-              const SizedBox(height: 32),
-              RichText(
-                text: TextSpan(
-                  style: theme.textTheme.headlineSmall,
-                  children: [
-                    const TextSpan(text: 'Welcome to '),
-                    TextSpan(
-                      text: 'HabitHero',
-                      style: TextStyle(color: theme.colorScheme.primary),
-                    ),
-                  ],
-                ),
+              const TextSpan(text: 'Welcome to '),
+              TextSpan(
+                text: 'HabitHero',
+                style: TextStyle(color: theme.colorScheme.primary),
               ),
-              const SizedBox(height: 16),
-              const _FeatureTile(
-                icon: Icons.check_circle_outline,
-                title: 'Track Habits',
-                subtitle: 'Monitor your daily progress',
-              ),
-              const _FeatureTile(
-                icon: Icons.alarm,
-                title: 'Reminders',
-                subtitle: 'Never forget a habit',
-              ),
-              const _FeatureTile(
-                icon: Icons.bar_chart,
-                title: 'Statistics',
-                subtitle: 'Visualize improvement',
-              ),
-              const _FeatureTile(
-                icon: Icons.stacked_line_chart,
-                title: 'Streaks',
-                subtitle: 'Stay motivated every day',
-              ),
-              const _FeatureTile(
-                icon: Icons.flag,
-                title: 'Goals',
-                subtitle: 'Set achievable targets',
-              ),
-              const _FeatureTile(
-                icon: Icons.widgets,
-                title: 'Widgets',
-                subtitle: 'Quick access on home',
-              ),
-              const _FeatureTile(
-                icon: Icons.dark_mode,
-                title: 'Dark Mode',
-                subtitle: 'Easy on the eyes',
-              ),
-              const _FeatureTile(
-                icon: Icons.privacy_tip,
-                title: 'Privacy',
-                subtitle: 'Your data stays local',
-              ),
-              const Spacer(),
-              FilledButton(
-                onPressed: () => controller.next(context),
-                child: const Text('Continue'),
-              ),
-              const SizedBox(height: 16),
             ],
           ),
         ),
-      ),
+        const SizedBox(height: 16),
+        const _FeatureTile(
+          icon: Icons.check_circle_outline,
+          title: 'Track Habits',
+          subtitle: 'Monitor your daily progress',
+        ),
+        const _FeatureTile(
+          icon: Icons.alarm,
+          title: 'Reminders',
+          subtitle: 'Never forget a habit',
+        ),
+        const _FeatureTile(
+          icon: Icons.bar_chart,
+          title: 'Statistics',
+          subtitle: 'Visualize improvement',
+        ),
+        const _FeatureTile(
+          icon: Icons.stacked_line_chart,
+          title: 'Streaks',
+          subtitle: 'Stay motivated every day',
+        ),
+        const _FeatureTile(
+          icon: Icons.flag,
+          title: 'Goals',
+          subtitle: 'Set achievable targets',
+        ),
+        const _FeatureTile(
+          icon: Icons.widgets,
+          title: 'Widgets',
+          subtitle: 'Quick access on home',
+        ),
+        const _FeatureTile(
+          icon: Icons.dark_mode,
+          title: 'Dark Mode',
+          subtitle: 'Easy on the eyes',
+        ),
+        const _FeatureTile(
+          icon: Icons.privacy_tip,
+          title: 'Privacy',
+          subtitle: 'Your data stays local',
+        ),
+        const Spacer(),
+        FilledButton(
+          onPressed: () => controller.next(context),
+          child: const Text('Continue'),
+        ),
+        const SizedBox(height: 16),
+      ],
     );
   }
 }

--- a/lib/features/onboarding/presentation/pages/whats_new_page.dart
+++ b/lib/features/onboarding/presentation/pages/whats_new_page.dart
@@ -1,5 +1,3 @@
-import 'dart:ui';
-
 import 'package:flutter/material.dart';
 import 'package:get_it/get_it.dart';
 
@@ -12,67 +10,76 @@ class WhatsNewPage extends StatelessWidget {
   Widget build(BuildContext context) {
     final controller = GetIt.I<OnboardingController>();
     return Scaffold(
-      body: SafeArea(
-        child: Padding(
-          padding: const EdgeInsets.all(24),
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              SizedBox(
-                height: 220,
-                child: Stack(
-                  children: [
-                    Align(
-                      alignment: const Alignment(-0.4, -0.2),
-                      child: Icon(Icons.smartphone, size: 160, color: Colors.grey.withOpacity(0.4)),
-                    ),
-                    Align(
-                      alignment: const Alignment(0.4, 0.2),
-                      child: Icon(Icons.smartphone, size: 160, color: Colors.grey.withOpacity(0.4)),
-                    ),
-                  ],
+      extendBodyBehindAppBar: true,
+      backgroundColor: Colors.transparent,
+      body: Container(
+        padding: const EdgeInsets.all(24),
+        child: SafeArea(
+          child: SingleChildScrollView(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                SizedBox(
+                  height: 220,
+                  child: Stack(
+                    children: [
+                      Align(
+                        alignment: const Alignment(-0.4, -0.2),
+                        child: Icon(
+                          Icons.smartphone,
+                          size: 160,
+                          color: Colors.grey.withOpacity(0.4),
+                        ),
+                      ),
+                      Align(
+                        alignment: const Alignment(0.4, 0.2),
+                        child: Icon(
+                          Icons.smartphone,
+                          size: 160,
+                          color: Colors.grey.withOpacity(0.4),
+                        ),
+                      ),
+                    ],
+                  ),
                 ),
-              ),
-              Container(
-                padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
-                decoration: BoxDecoration(
-                  color: Theme.of(context).colorScheme.primary,
-                  borderRadius: BorderRadius.circular(8),
+                Container(
+                  padding: const EdgeInsets.symmetric(
+                    horizontal: 8,
+                    vertical: 4,
+                  ),
+                  decoration: BoxDecoration(
+                    color: Theme.of(context).colorScheme.primary,
+                    borderRadius: BorderRadius.circular(8),
+                  ),
+                  child: const Text(
+                    'MAJOR UPDATE',
+                    style: TextStyle(color: Colors.white),
+                  ),
                 ),
-                child: const Text(
-                  'MAJOR UPDATE',
-                  style: TextStyle(color: Colors.white),
+                const SizedBox(height: 16),
+                Text(
+                  'New Habit Detail View',
+                  style: Theme.of(context).textTheme.headlineSmall,
                 ),
-              ),
-              const SizedBox(height: 16),
-              Text(
-                'New Habit Detail View',
-                style: Theme.of(context).textTheme.headlineSmall,
-              ),
-              const SizedBox(height: 8),
-              const Text(
-                'Experience a redesigned habit view with improved interactions.',
-              ),
-              const SizedBox(height: 16),
-              const _FeatureTile(
-                icon: Icons.event,
-                title: 'Integrated Calendar',
-              ),
-              const _FeatureTile(
-                icon: Icons.list_alt,
-                title: 'Compact List',
-              ),
-              const _FeatureTile(
-                icon: Icons.bug_report,
-                title: 'Bugfixes',
-              ),
-              const Spacer(),
-              FilledButton(
-                onPressed: () => controller.next(context),
-                child: const Text('Continue'),
-              ),
-              const SizedBox(height: 16),
-            ],
+                const SizedBox(height: 8),
+                const Text(
+                  'Experience a redesigned habit view with improved interactions.',
+                ),
+                const SizedBox(height: 16),
+                const _FeatureTile(
+                  icon: Icons.event,
+                  title: 'Integrated Calendar',
+                ),
+                const _FeatureTile(icon: Icons.list_alt, title: 'Compact List'),
+                const _FeatureTile(icon: Icons.bug_report, title: 'Bugfixes'),
+                const Spacer(),
+                FilledButton(
+                  onPressed: () => controller.next(context),
+                  child: const Text('Continue'),
+                ),
+                const SizedBox(height: 16),
+              ],
+            ),
           ),
         ),
       ),


### PR DESCRIPTION
## Summary
- fix missing Material ancestors on onboarding pages
- wrap `WelcomePage` and `WhatsNewPage` in a transparent `Scaffold`
- nest `ThemeChoicePage` content inside `SafeArea`
- extract `_FeatureList` from `WelcomePage`

## Testing
- `flutter analyze lib`

------
https://chatgpt.com/codex/tasks/task_e_68777a8ad0b4832995b8f61af0fd661f